### PR TITLE
fix(sse): normalize string ID to int in server messages for compatibi…

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -87,6 +87,19 @@ async def sse_client(
                                             message = types.JSONRPCMessage.model_validate_json(  # noqa: E501
                                                 sse.data
                                             )
+
+                                            # Extract the message ID safely from the root object
+                                            msg_id = getattr(getattr(message, "root", None), "id", None)
+
+                                            # Normalize ID to integer if it's a numeric string
+                                            # Some non-standard SSE servers may return numeric IDs as strings,
+                                            # even if the original request used an integer ID.
+                                            if isinstance(msg_id, str) and msg_id.isdigit():
+                                                message.root.id = int(msg_id)
+                                            elif not isinstance(msg_id, int):
+                                                logger.warning(f"Ignored message with invalid ID: {msg_id!r}")
+                                                continue
+
                                             logger.debug(
                                                 f"Received server message: {message}"
                                             )


### PR DESCRIPTION
### Normalize `message.root.id` to `int` for SSE compatibility

Some non-compliant SSE servers may return numeric IDs as strings, even when the client originally sent them as integers. This can lead to issues where the response ID no longer matches the original request ID, causing callbacks to fail and the client to hang indefinitely.

This change ensures that `message.root.id` is coerced to an integer when appropriate, maintaining type consistency and restoring proper request-response matching.
